### PR TITLE
New sidecar behaviour toggle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CURRENTOS := $(shell go env GOOS)
 CURRENTARCH := $(shell go env GOARCH)
 COMMIT := $(shell git rev-parse --short HEAD)
-VERSION := v1.3.0
+VERSION := v1.3.1
 LDFLAGS="-X main.buildVersion=$(VERSION) -X main.commitVersion=$(COMMIT)"
 
 .DEFAULT_GOAL := build

--- a/util/flags.go
+++ b/util/flags.go
@@ -105,7 +105,8 @@ func (f *CliFlags) RunMode() RunMode {
 func ProcessFlags(args []string) (*CliFlags, error) {
 	var flags CliFlags
 
-	app := kingpin.New("vault-ctrl-tool", "A handy tool for interacting with HashiCorp Vault")
+	app := kingpin.New("vault-ctrl-tool", "A handy tool for interacting with HashiCorp Vault\n\n"+
+		"Boolean flags can be disabled through using the complement flag by adding prefixing it with 'no-' (for example: '--no-enable-prometheus-metrics")
 
 	app.Flag("init", "Run in init mode, process templates and exit.").Default("false").BoolVar(&flags.PerformInit)
 	app.Flag("config", "Full path of the config file to read.").Default("vault-config.yml").StringVar(&flags.ConfigFile)

--- a/util/flags.go
+++ b/util/flags.go
@@ -106,7 +106,7 @@ func ProcessFlags(args []string) (*CliFlags, error) {
 	var flags CliFlags
 
 	app := kingpin.New("vault-ctrl-tool", "A handy tool for interacting with HashiCorp Vault\n\n"+
-		"Boolean flags can be disabled through using the complement flag by adding prefixing it with 'no-' (for example: '--no-enable-prometheus-metrics")
+		"Boolean flags can be disabled through using the complement flag by adding prefixing it with 'no-' (for example: '--no-enable-prometheus-metrics).")
 
 	app.Flag("init", "Run in init mode, process templates and exit.").Default("false").BoolVar(&flags.PerformInit)
 	app.Flag("config", "Full path of the config file to read.").Default("vault-config.yml").StringVar(&flags.ConfigFile)

--- a/util/flags.go
+++ b/util/flags.go
@@ -41,6 +41,7 @@ type CliFlags struct {
 	PrometheusPort          int           // configures port on which to serve prometheus metrics endpoint
 	VaultClientTimeout      time.Duration // configures HTTP timeouts for Vault client connections.
 	VaultClientRetries      int           // configures HTTP retries for Vault client connections.
+	TerminateOnSyncFailure  bool          // If enabled in sidecar mode, will cause tool to terminate if there is a failure to perform sync.
 }
 
 type RunMode int
@@ -160,6 +161,9 @@ func ProcessFlags(args []string) (*CliFlags, error) {
 	// Vault client options
 	app.Flag("vault-client-timeout", "timeout duration for vault client HTTP timeouts").Default("30s").DurationVar(&flags.VaultClientTimeout)
 	app.Flag("vault-client-retries", "number of retries to be performed for vault client operations").Default("2").IntVar(&flags.VaultClientRetries)
+
+	// Sidecar mode options
+	app.Flag("terminate-on-sync-failure", "if enabled in sidecar mode, will cause tool to terminate if there is a failure to perform sync").Default("true").BoolVar(&flags.TerminateOnSyncFailure)
 
 	_, err := app.Parse(args)
 	if err != nil {

--- a/util/flags.go
+++ b/util/flags.go
@@ -106,7 +106,7 @@ func ProcessFlags(args []string) (*CliFlags, error) {
 	var flags CliFlags
 
 	app := kingpin.New("vault-ctrl-tool", "A handy tool for interacting with HashiCorp Vault\n\n"+
-		"Boolean flags can be disabled through using the complement flag by adding prefixing it with 'no-' (for example: '--no-enable-prometheus-metrics).")
+		"Boolean flags can be disabled through using the complement flag by prefixing it with 'no-' (for example: '--no-enable-prometheus-metrics).")
 
 	app.Flag("init", "Run in init mode, process templates and exit.").Default("false").BoolVar(&flags.PerformInit)
 	app.Flag("config", "Full path of the config file to read.").Default("vault-config.yml").StringVar(&flags.ConfigFile)

--- a/util/flags.go
+++ b/util/flags.go
@@ -106,7 +106,7 @@ func ProcessFlags(args []string) (*CliFlags, error) {
 	var flags CliFlags
 
 	app := kingpin.New("vault-ctrl-tool", "A handy tool for interacting with HashiCorp Vault\n\n"+
-		"Boolean flags can be disabled through using the complement flag by prefixing it with 'no-' (for example: '--no-enable-prometheus-metrics).")
+		"Boolean flags can be disabled through using the complement flag by prefixing it with 'no-' (for example: '--no-token-renewable).")
 
 	app.Flag("init", "Run in init mode, process templates and exit.").Default("false").BoolVar(&flags.PerformInit)
 	app.Flag("config", "Full path of the config file to read.").Default("vault-config.yml").StringVar(&flags.ConfigFile)
@@ -156,7 +156,7 @@ func ProcessFlags(args []string) (*CliFlags, error) {
 	app.Flag("never-scrub", "ignored; kept for compatibility").Default("false").Bool()
 
 	// Metrics options
-	app.Flag("enable-prometheus-metrics", "enables prometheus metrics to be served on prometheus-metrics port").Default("true").BoolVar(&flags.EnablePrometheusMetrics)
+	app.Flag("enable-prometheus-metrics", "enables prometheus metrics to be served on prometheus-metrics port").Default("false").BoolVar(&flags.EnablePrometheusMetrics)
 	app.Flag("prometheus-port", "specifies prometheus metrics port").Default("9191").IntVar(&flags.PrometheusPort)
 
 	// Vault client options


### PR DESCRIPTION
* Sidecar terminate on failure is disabled by default now.
* Prometheus server is disabled by default now to avoid breaking use cases where default port cannot be bound
* Add blurb to help that explains how to use the boolean flags